### PR TITLE
Change RL_VERSION to use latest or at least current version

### DIFF
--- a/rl_bulk_enable.sh
+++ b/rl_bulk_enable.sh
@@ -9,7 +9,7 @@
 
 #local working directory
 RL10_WORKING_DIR='rightscale_rl10'
-RL_VERSION='10.2.1'
+RL_VERSION='10'  # use latest RL10 version; if you want to use a specific version change accordingly (e.g. 10.6.0)
 
 #use sshpass for passing the password ssh when not using a key
 #MAC OSX brew install https://git.io/sshpass.rb


### PR DESCRIPTION
RL_VERSION is set to 10.2.1 which is an out of date RightLink agent version.
Suggesting to change it simply to "10" so that it will use the latest RL version.
Or update it to the current version which is "10.6.0"